### PR TITLE
Changed Application Shortcuts to No Longer Conflict with OpenStep

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/build
+/buildx
+.DS_Store

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,7 +5,8 @@ set(SOURCES
 	floppy.c grab.c ioMem.c ioMemTabNEXT.c ioMemTabTurbo.c keymap.c kms.c 
 	m68000.c main.c mo.c nbic.c ncc.c NextBus.cpp paths.c printer.c queue.c 
 	ramdac.c reset.c rom.c rs.c rtcnvram.c scandir.c scc.c screen.c host.c 
-	scsi.c shortcut.c snd.c statusbar.c str.c sysReg.c tmc.c video.c zip.c)
+	scsi.c shortcut.c snd.c statusbar.c str.c sysReg.c tmc.c video.c zip.c
+	gui-osx/gui-osx.m)
 
 # When building for macOS, define specific sources for gui and resources
 if(ENABLE_OSX_BUNDLE)
@@ -151,6 +152,24 @@ if(HAIKU)
 	# Needed for socket() on Haiku
 	target_link_libraries(${APP_NAME} network)
 endif(HAIKU)
+
+ENABLE_LANGUAGE(OBJC)
+find_library(APPKIT_LIBRARY AppKit)
+if (NOT APPKIT_LIBRARY)
+  message(STATUS "AppKit.framework NOT found!")
+else()
+  message(STATUS "AppKit.framework found! ${APPKIT_LIBRARY}")
+endif()
+
+find_library(FOUNDATION_LIBRARY Foundation)
+if (NOT FOUNDATION_LIBRARY)
+  message(STATUS "Foundation.framework NOT found!")
+else()
+  message(STATUS "Foundation.framework found! ${FOUNDATION_LIBRARY}")
+endif()
+
+target_link_libraries(${APP_NAME} ${FOUNDATION_LIBRARY})
+target_link_libraries(${APP_NAME} ${APPKIT_LIBRARY})
 
 if(ENABLE_OSX_BUNDLE)
 	install(TARGETS ${APP_NAME} BUNDLE DESTINATION /Applications)

--- a/src/gui-osx/gui-osx.m
+++ b/src/gui-osx/gui-osx.m
@@ -1,0 +1,155 @@
+/*
+  Previous - gui-osx.m
+
+  This file is distributed under the GNU General Public License, version 2
+  or at your option any later version. Read the file gpl.txt for details.
+
+  This file listens for the the Application to launch and for the window to open
+  and then modifies the menu items and toolbar buttons to avoid conflicts
+  with the openstep operating system and to remove fullscreen which does not
+  work correctly when activated by OSX. Rather fullscreen should be activated
+  via the shortcut (Control + Option + F)
+  
+  Contributed by Jeffrey Bergier on 2024/11/01
+*/
+
+#import <AppKit/AppKit.h>
+
+@interface PreviousGUI: NSObject
+@end
+
+@interface NSMenuItem (Previous)
+/// Returns YES if the modification was made
+-(BOOL)PREV_setKeyEquivalentModifierMask:(NSEventModifierFlags)desiredMask
+                          ifExpectedMask:(NSEventModifierFlags)expectedMask
+                          andExpectedKey:(NSString*)expectedKey;
+-(BOOL)PREV_removeFromMenu;
+@end
+
+@interface NSMenu (Previous)
+-(NSArray*)PREV_itemArrayWithSubitems;
+@end
+
+@implementation PreviousGUI
+
+// MARK: Subscribe to notifications
+
++(void)load;
+{
+  [[NSNotificationCenter defaultCenter] addObserver:self
+                                           selector:@selector(applicationDidFinishLaunching:)
+                                               name:NSApplicationDidFinishLaunchingNotification
+                                             object:nil];
+  [[NSNotificationCenter defaultCenter] addObserver:self
+                                           selector:@selector(windowDidBecomeKey:)
+                                               name:NSWindowDidBecomeKeyNotification
+                                             object:nil];
+}
+
+// MARK: Menu Shortcut Customizing
++(void)applicationDidFinishLaunching:(NSNotification*)aNotification;
+{
+  NSInteger processd = 0;
+  NSInteger modified = 0;
+  NSArray *menuItems = [[(NSApplication*)[aNotification object] mainMenu] PREV_itemArrayWithSubitems];
+  
+  for (NSMenuItem *item in menuItems) {
+    SEL action = [item action];
+    if (action == @selector(terminate:)) { // Quit Application
+      modified += [item PREV_setKeyEquivalentModifierMask:NSEventModifierFlagCommand | NSEventModifierFlagOption
+                                           ifExpectedMask:NSEventModifierFlagCommand
+                                           andExpectedKey:@"q"];
+    } else if (action == @selector(hide:)) { // Hide Application
+      modified += [item PREV_setKeyEquivalentModifierMask:NSEventModifierFlagCommand | NSEventModifierFlagOption
+                                           ifExpectedMask:NSEventModifierFlagCommand
+                                           andExpectedKey:@"h"];
+    } else if (action == @selector(hideOtherApplications:)) { // Hide Other Applications
+      modified += [item PREV_setKeyEquivalentModifierMask:NSEventModifierFlagCommand | NSEventModifierFlagOption | NSEventModifierFlagShift
+                                           ifExpectedMask:NSEventModifierFlagCommand | NSEventModifierFlagOption
+                                           andExpectedKey:@"h"];
+    } else if (action == @selector(performMiniaturize:)) { // Minimize Window
+      modified += [item PREV_setKeyEquivalentModifierMask:NSEventModifierFlagCommand | NSEventModifierFlagOption
+                                           ifExpectedMask:NSEventModifierFlagCommand
+                                           andExpectedKey:@"m"];
+    } else if (action == @selector(performClose:)) { // Close Window
+      modified += [item PREV_setKeyEquivalentModifierMask:NSEventModifierFlagCommand | NSEventModifierFlagOption
+                                           ifExpectedMask:NSEventModifierFlagCommand
+                                           andExpectedKey:@"w"];
+    } else if ([[item keyEquivalent] isEqualToString:@","]) { // Open Application Settings
+      modified += [item PREV_setKeyEquivalentModifierMask:NSEventModifierFlagCommand | NSEventModifierFlagOption
+                                           ifExpectedMask:NSEventModifierFlagCommand
+                                           andExpectedKey:@","];
+    } else if (action == @selector(closeAll:)) { // Close All Windows
+      modified += [item PREV_removeFromMenu];
+    } else if (action == @selector(toggleFullScreen:)) { // Enter Full Screen Mode
+      modified += [item PREV_removeFromMenu];
+    } else {
+      continue;
+    }
+    processd += 1;
+  }
+  
+  [[NSNotificationCenter defaultCenter] removeObserver:self
+                                                  name:NSApplicationDidFinishLaunchingNotification
+                                                object:nil];
+  NSLog(@"%@: Processed Main Menu: %ld total -> %ld processed -> %ld modified",
+        self, [menuItems count], processd, modified);
+}
+
+// MARK: Window Zoom Button Disabling
++(void)windowDidBecomeKey:(NSNotification*)aNotification;
+{
+  NSWindow *window = [aNotification object];
+  if ([window collectionBehavior] & NSWindowCollectionBehaviorFullScreenNone) { return; }
+  
+  Class sdl3WindowClass = NSClassFromString(@"SDL3Window");
+  Class sdl2WindowClass = NSClassFromString(@"SDLWindow");
+  if (![window isKindOfClass:sdl3WindowClass] && ![window isKindOfClass:sdl2WindowClass]) { return; }
+  
+  [window setCollectionBehavior:NSWindowCollectionBehaviorFullScreenNone];
+  [[NSNotificationCenter defaultCenter] removeObserver:self
+                                                  name:NSWindowDidBecomeKeyNotification
+                                                object:nil];
+  NSLog(@"%@: %@ Disabled Full Screen Button",self, window);
+}
+
+@end
+
+@implementation NSMenuItem (Previous)
+
+-(BOOL)PREV_setKeyEquivalentModifierMask:(NSEventModifierFlags)desiredMask
+                          ifExpectedMask:(NSEventModifierFlags)expectedMask
+                          andExpectedKey:(NSString*)expectedKey;
+{
+  if ([[self keyEquivalent] isEqualToString:expectedKey]
+      && [self keyEquivalentModifierMask] == expectedMask)
+  {
+    [self setKeyEquivalentModifierMask:desiredMask];
+    return YES;
+  }
+  return NO;
+}
+
+-(BOOL)PREV_removeFromMenu;
+{
+  [[self menu] removeItem:self];
+  return YES;
+}
+
+@end
+
+@implementation NSMenu (Previous)
+
+-(NSArray*)PREV_itemArrayWithSubitems;
+{
+  NSMutableArray *output = [[NSMutableArray new] autorelease];
+  for (NSMenuItem *item in [self itemArray]) {
+    [output addObject:item];
+    if ([item hasSubmenu]) {
+      [output addObjectsFromArray:[[item submenu] PREV_itemArrayWithSubitems]];
+    }
+  }
+  return [[output copy] autorelease];
+}
+
+@end


### PR DESCRIPTION
Because OpenStep shares keyboard shortcuts with the Mac, the NSWindow captures the common shortcuts and sends them to the Host Operating System before the emulator can capture them and send them to the Guest Operating System.

This change changes the shortcuts so they no longer conflict. The Mac ones are not disabled, they are just changed to no longer conflict with OpenStep.

This also disables the full screen zoom feature which does not work properly. Users should use the Control Option F full screen feature of Hatari

![PreviousChanges](https://github.com/user-attachments/assets/39e611a0-710b-4f8f-9cb0-d029142436ef)
